### PR TITLE
Enable list file actions to act on a selection, if active

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -1,5 +1,13 @@
 Magit-annex NEWS -- history of user-visible changes   -*- mode: org; -*-
 
+* master (unreleased)
+
+** New features
+
+- In ~magit-annex-list-mode~ buffers, file action commands now
+  consider files selected by the region when choosing a default for
+  completion.
+
 * 1.5.0
 
 Magit-annex has been updated for the latest version of Magit and now

--- a/magit-annex.el
+++ b/magit-annex.el
@@ -388,15 +388,19 @@ With a prefix argument, prompt for FILE.
      ,(format "%s FILES.\n\n  git annex %s [ARGS] [FILE...]"
               (capitalize command) command)
      (interactive
-      (list (let ((atpoint (cdr (magit-section-when annex-list-file))))
-              (magit-annex-read-files
-               (concat ,(capitalize command)
-                       " file,s"
-                       (and atpoint (format " (%s)" atpoint))
-                       ": ")
-               ,limit
-               atpoint))
-            (magit-annex-file-action-arguments)))
+      (list
+       (let ((default (--when-let (or (mapcar #'cdr (magit-region-values 'annex-list-file))
+                                      (-some-> (cdr (magit-section-when annex-list-file))
+                                               (list)))
+                        (mapconcat #'identity it ","))))
+         (magit-annex-read-files
+          (concat ,(capitalize command)
+                  " file,s"
+                  (and default (format " (%s)" default))
+                  ": ")
+          ,limit
+          default))
+       (magit-annex-file-action-arguments)))
      (magit-with-toplevel
        (,(if no-async 'magit-annex-run 'magit-annex-run-async)
         ,command args files))))

--- a/magit-annex.el
+++ b/magit-annex.el
@@ -616,7 +616,7 @@ Type \\[magit-annex-unused-open] to open the file.
 
 \\<magit-annex-list-mode-map>\
 Type \\[magit-annex-file-action-popup] to perform git-annex action
-on the file at point.
+on the files selected by the region (if active) or the file at point.
 \n\\{magit-annex-list-mode-map}"
   :group 'magit-modes
   (hack-dir-local-variables-non-file-buffer))

--- a/magit-annex.el
+++ b/magit-annex.el
@@ -388,7 +388,7 @@ With a prefix argument, prompt for FILE.
      ,(format "%s FILES.\n\n  git annex %s [ARGS] [FILE...]"
               (capitalize command) command)
      (interactive
-      (list (let ((atpoint (magit-annex-list-file-at-point)))
+      (list (let ((atpoint (cdr (magit-section-when annex-list-file))))
               (magit-annex-read-files
                (concat ,(capitalize command)
                        " file,s"
@@ -678,9 +678,6 @@ on the file at point.
       (magit-insert-section (annex-list-file (cons locs file))
         (insert (format "%s %s" locs file))
         (forward-line)))))
-
-(defun magit-annex-list-file-at-point ()
-  (cdr (magit-section-when annex-list-file)))
 
 (provide 'magit-annex)
 


### PR DESCRIPTION
In the git annex list popup, file actions currently only act on the file at point. This change allows you to select a region of files and act on that selection.