### PR TITLE
Explicitly depend on transient

### DIFF
--- a/magit-annex.el
+++ b/magit-annex.el
@@ -7,7 +7,7 @@
 ;; URL: https://github.com/magit/magit-annex
 ;; Keywords: vc tools
 ;; Version: 1.7.1
-;; Package-Requires: ((cl-lib "0.3") (magit "2.90.0"))
+;; Package-Requires: ((cl-lib "0.3") (magit "2.90.0") (transient "0.2.0"))
 
 ;; This program is free software; you can redistribute it and/or modify
 ;; it under the terms of the GNU General Public License as published by


### PR DESCRIPTION
As magit-annex require transient, it probably should explicitly
depend on it.

Then if magit change it own depend, magit-annex will continue to be
installable, and usable.
